### PR TITLE
create migration directory on start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: docker compose -f docker-compose.test.yml up -d
 
       - name: Test
-        run: pnpm test:ci
+        run: pnpm test:coverage
 
       - name: Tear down test environment
         run: docker compose -f docker-compose.test.yml down

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,6 @@ services:
   db_test:
     image: postgres:15
     container_name: db-test
-    env_file: .env.test
     environment:
       POSTGRES_USER: "${DB_USER}"
       POSTGRES_PASSWORD: "${DB_PASSWORD}"
@@ -24,7 +23,6 @@ services:
   redis_test:
     image: redis:6.2.6
     container_name: ${APP_NAME}-redis-test
-    env_file: .env.test
     command: redis-server --appendonly yes
     ports:
       - "6379:6379"

--- a/src/plugins/db.ts
+++ b/src/plugins/db.ts
@@ -1,4 +1,6 @@
 import fp from "fastify-plugin";
+import fs from "fs";
+import path from "path";
 import { db, migrator } from "../database";
 
 /**
@@ -9,6 +11,12 @@ export default fp(
     // Migrate the database to the latest version
     fastify.addHook("onReady", async () => {
       if (fastify.config.MIGRATE_ON_START === true) {
+        const migrationDir = path.join(__dirname, "../migrations");
+
+        if (!fs.existsSync(migrationDir)) {
+          fs.mkdirSync(migrationDir);
+        }
+
         const { error, results } = await migrator.migrateToLatest();
 
         results?.forEach((it) => {


### PR DESCRIPTION
### TL;DR
Removed redundant env file references and added automatic migration directory creation

### What changed?
- Removed duplicate `.env.test` references from docker-compose test services
- Added automatic creation of migrations directory if it doesn't exist before running migrations

### How to test?
1. Delete the migrations directory
2. Start the application with `MIGRATE_ON_START=true`
3. Verify that the migrations directory is created automatically
4. Verify that docker-compose test services still work correctly without the `.env.test` references

### Why make this change?
- Prevents migration errors when the migrations directory doesn't exist
- Removes redundant environment file references since the variables are already being passed through environment block in docker-compose