### PR TITLE
add pushpress/datadog

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -9,7 +9,7 @@ on:
       - ".github/workflows/api.yaml"
 
 jobs:
-  test:
+  Test:
     runs-on: ubuntu-latest
 
     steps:
@@ -36,7 +36,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/spa.yml
+++ b/.github/workflows/spa.yml
@@ -28,7 +28,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           pnpm install --frozen-lockfile
+        env:
+          NPM_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Lint
         run: pnpm lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-@pushpress:registry=https://registry.npmjs.org/
+registry=https://registry.npmjs.org/
+@pushpress:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fastify/static": "^8.0.3",
     "@fastify/swagger": "^9.4.0",
     "@fastify/swagger-ui": "^5.2.0",
+    "@pushpress/datadog": "^0.4.2",
     "bullmq": "^5.34.5",
     "dd-trace": "^5.30.0",
     "dotenv": "^16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.0
         version: 5.2.0
+      '@pushpress/datadog':
+        specifier: ^0.4.2
+        version: 0.4.2
       bullmq:
         specifier: ^5.34.5
         version: 5.34.5
@@ -913,6 +916,9 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@pushpress/datadog@0.4.2':
+    resolution: {integrity: sha512-iWgpeE6Sm+7elsxvlu344AGGcgXdoa8R74HBmxoKb93JIgWzWgmXh2btGJNksyeejfb8UICSHu6FXTyQvZOcdA==, tarball: https://npm.pkg.github.com/download/@pushpress/datadog/0.4.2/31cebabc7eb1d5125da2af591d72b28168eb1591}
 
   '@rollup/rollup-android-arm-eabi@4.29.1':
     resolution: {integrity: sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==}
@@ -3723,6 +3729,11 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@pushpress/datadog@0.4.2':
+    dependencies:
+      dd-trace: 5.30.0
+      ts-pattern: 5.6.0
 
   '@rollup/rollup-android-arm-eabi@4.29.1':
     optional: true

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -1,0 +1,11 @@
+import { initDDTracer } from "@pushpress/datadog";
+import tracer from "dd-trace";
+
+export function newTracer() {
+  return initDDTracer({
+    tracer,
+    metrics: [],
+  });
+}
+
+export type Tracer = Awaited<ReturnType<typeof newTracer>>;


### PR DESCRIPTION
### TL;DR
Adds Datadog tracing integration to the application using the @pushpress/datadog package.

### What changed?
- Added @pushpress/datadog package as a dependency
- Created a new datadog.ts file to initialize the Datadog tracer
- Modified app.ts to use the new tracer and expose it via FastifyInstance
- Converted the app plugin from callback to async/await pattern

### How to test?
1. Install dependencies with `pnpm install`
2. Start the application
3. Verify Datadog traces are being sent to your Datadog instance
4. Check that the tracer is accessible via `fastify.tracer`

### Why make this change?
To enable application performance monitoring and distributed tracing capabilities through Datadog, allowing better observability and debugging of the application in production environments.