### PR TITLE
DEV-317: Enable streaming feature flag updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@pushpress/datadog": "^0.5.0",
     "bullmq": "^5.40.2",
     "dd-trace": "^5.36.0",
-    "@pushpress/fastify-feature-flags": "0.11.0",
+    "@pushpress/fastify-feature-flags": "0.12.0",
     "dotenv": "^16.4.7",
     "eventemitter2": "^6.4.9",
     "fastify": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       '@pushpress/fastify-feature-flags':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.12.0
+        version: 0.12.0
       bullmq:
         specifier: ^5.40.2
         version: 5.40.2
@@ -1034,8 +1034,8 @@ packages:
   '@pushpress/datadog@0.5.0':
     resolution: {integrity: sha512-gFG/CDenw6xmi/ihnuVacsgbCLX5lv3mk0JbxByMunOpWHGG4DtLMCzQDP239dBAAo9W/aqGlVPJST23R47mxg==, tarball: https://npm.pkg.github.com/download/@pushpress/datadog/0.5.0/4f5c63e2c403c25517ed22c8174b2d8ca759c148}
 
-  '@pushpress/fastify-feature-flags@0.11.0':
-    resolution: {integrity: sha512-eRLgZsI90nmCYSDqw7QDeqwV3psw32cnxStwlyKWqcryiMR0bzRcrNjx/KmfXsctnLcY7VzhF4eHFQHRIjA13A==, tarball: https://npm.pkg.github.com/download/@pushpress/fastify-feature-flags/0.11.0/411fc3dfba30268f2cfc80fb46d6f5d7f4f45720}
+  '@pushpress/fastify-feature-flags@0.12.0':
+    resolution: {integrity: sha512-osVKyvDgCH5ghiTuErlZkQl34/E3J0/uuFllVFItLp1kx54cVFpCs+0WMC9PDGcWFNaGT/ASvgfk4Sg/6ijUUg==, tarball: https://npm.pkg.github.com/download/@pushpress/fastify-feature-flags/0.12.0/4ea938a013fca1438a4255c7485a9622af0dd32c}
 
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
@@ -4366,7 +4366,7 @@ snapshots:
       dd-trace: 5.36.0
       ts-pattern: 5.6.2
 
-  '@pushpress/fastify-feature-flags@0.11.0':
+  '@pushpress/fastify-feature-flags@0.12.0':
     dependencies:
       '@growthbook/growthbook': 1.3.1
       eventsource: 3.0.5

--- a/src/plugins/env.ts
+++ b/src/plugins/env.ts
@@ -70,6 +70,10 @@ const schema = {
     GROWTHBOOK_CLIENT_KEY: {
       type: "string",
     },
+    GROWTHBOOK_ENABLE_STREAMING: {
+      type: "boolean",
+      default: true,
+    },
   },
 } as const satisfies JSONSchema;
 

--- a/src/plugins/feature-flags/index.ts
+++ b/src/plugins/feature-flags/index.ts
@@ -17,6 +17,7 @@ export default fp(
     const environment = opts.overrideEnv ?? fastify.config.NODE_ENV;
     const clientKey = fastify.config.GROWTHBOOK_CLIENT_KEY;
     const apiHost = fastify.config.GROWTHBOOK_API_HOST;
+    const streaming = fastify.config.GROWTHBOOK_ENABLE_STREAMING;
 
     const client = await createGrowthBookClient<
       Environments,
@@ -28,6 +29,7 @@ export default fp(
       environment,
       initWaitTimeoutMs: 5000 /* init can block for up to 5 seconds */,
       fallbacks,
+      streaming,
     });
 
     fastify.decorate("featureFlags", client);


### PR DESCRIPTION
Pulls in 0.12.0 of the feature flag plugin, which allows for streaming updates.

Adds a new environment variable to toggle streaming behavior on and off. It's enabled by default. 